### PR TITLE
Fixed the text query parameter

### DIFF
--- a/index.html
+++ b/index.html
@@ -455,7 +455,15 @@
 
 		<script>
 			var matrix = new Matrix(document.getElementsByTagName('canvas')[0]);
-			matrix.rain();
+			var regex = new RegExp("[?&]text(=([^&#]*)|&|#|$)"), results = regex.exec(window.location.search);
+			var text = (!results ? null : !results[2] ? '' : decodeURIComponent(results[2].replace(/\+/g, " ")));
+			
+			if (text === null) {
+				matrix.rain();
+			} else {
+				matrix.write(text);
+				setTimeout(function() { matrix.rain() }, 15000)
+			}
 
 			document.addEventListener('keydown', function(e) {
 				if (e.key === "f") {


### PR DESCRIPTION
The `write` function should be rewritten to be in a callback so that when the text is done writing, the callback is executed.
This version sets a timeout to rain 15 seconds after the page is loaded. If the text is long enough, the rain might start before the text is finished writing.